### PR TITLE
Rules without manipulators rejected in karabiner

### DIFF
--- a/macOS/ultimate_macOS.json
+++ b/macOS/ultimate_macOS.json
@@ -1,12 +1,9 @@
 {
-    "title": "ultimate macOS",
+    "title": "ultimate macOS (version: 1556140183)",
     "maintainers": ["suliveevil"],
     "homepage": "https://github.com/suliveevil/Capslock",
     "import_url": "karabiner://karabiner/assets/complex_modifications/import?url=https://raw.githubusercontent.com/suliveevil/Capslock/master/mac/ultimate_macOS.json",
     "rules": [
-        {
-            "description": "ultimate macOS (version: 1556140182)"
-        },
         {
             "description": "KBD: BluetoothConverter、IKBC_C87、XD60: Swap Win/CMD and Alt/Opt",
             "manipulators": [


### PR DESCRIPTION
In the latest karabiner 12.10.0 it's no longer allowed to have a rules with just a description without and manipulators. 
As a result to make this usable again I've removed the offending line and moved the version information to the title instead.